### PR TITLE
feat: implement more precise error handling in frontend

### DIFF
--- a/frontend/src/components/common/ErrorToast.tsx
+++ b/frontend/src/components/common/ErrorToast.tsx
@@ -1,0 +1,18 @@
+import Toast from "react-bootstrap/Toast";
+import { useErrorContext } from "../../context/ErrorContext";
+
+const ErrorToast = () => {
+  const { error, clearError } = useErrorContext();
+
+  if (!error) return null;
+
+  return (
+    <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 1050 }}>
+      <Toast bg="danger" show autohide delay={5000} onClose={clearError}>
+        <Toast.Body className="text-white">{error}</Toast.Body>
+      </Toast>
+    </div>
+  );
+};
+
+export default ErrorToast;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -2,3 +2,4 @@ export { default as ErrorAlert } from "./ErrorAlert";
 export { default as Footer } from "./Footer";
 export { default as Loading } from "./Loading";
 export { default as AppNavbar } from "./Navbar";
+export { default as ErrorToast } from "./ErrorToast";

--- a/frontend/src/components/layout/AppContent.tsx
+++ b/frontend/src/components/layout/AppContent.tsx
@@ -2,9 +2,19 @@ import { Container } from "react-bootstrap";
 import { useAuthContext } from "../../context/AuthContext";
 import { Loading, AppNavbar, Footer, ErrorAlert } from "../common";
 import AppRoutes from "../../AppRoutes";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useErrorContext } from "../../context/ErrorContext";
 
 const AppContent = () => {
   const { authLoading } = useAuthContext();
+  const location = useLocation();
+  const { clearError } = useErrorContext();
+
+  // ルートが変わるたびにエラーをクリア
+  useEffect(() => {
+    clearError();
+  }, [location.pathname, clearError]);
 
   if (authLoading) {
     return <Loading message="認証情報を確認中..." />;

--- a/frontend/src/components/layout/AppContent.tsx
+++ b/frontend/src/components/layout/AppContent.tsx
@@ -1,6 +1,6 @@
 import { Container } from "react-bootstrap";
 import { useAuthContext } from "../../context/AuthContext";
-import { Loading, AppNavbar, Footer, ErrorAlert } from "../common";
+import { Loading, AppNavbar, Footer, ErrorToast } from "../common";
 import AppRoutes from "../../AppRoutes";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
@@ -24,9 +24,9 @@ const AppContent = () => {
     <>
       <AppNavbar />
       <Container className="mt-4 flex-grow-1">
-        <ErrorAlert />
         <AppRoutes />
       </Container>
+      <ErrorToast />
       <Footer />
     </>
   );

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -64,6 +64,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const token = data.key;
       if (!token) throw new Error("サーバーからトークンが返されませんでした。");
 
+      // 成功したのでグローバルエラーはクリア
+      setError(null);
+
       // 認証情報を state と localStorage に保存
       setToken(token);
       setCurrentUsername(user.username);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -56,14 +56,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const login = async (user: LoginRequest): Promise<void> => {
     if (!user || !user.username || !user.password) {
-      setError("ユーザー名とパスワードが必要です。");
-      throw new Error("認証が失敗しました。");
+      throw new Error("ユーザー名とパスワードが必要です。");
     }
 
     try {
       const data = await AuthService.login(user);
       const token = data.key;
-
       if (!token) throw new Error("サーバーからトークンが返されませんでした。");
 
       // 認証情報を state と localStorage に保存
@@ -71,12 +69,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       setCurrentUsername(user.username);
       localStorage.setItem(LOCALSTORAGE_TOKEN_KEY, token);
       localStorage.setItem(LOCALSTORAGE_USERNAME_KEY, user.username);
-
-      setError(""); // 成功時はエラーをクリア
     } catch (e: any) {
       console.error("login error:", e);
-      // interceptor で加工済みなので e.message をそのまま使う
-      setError(e.message || "ログインに失敗しました。");
+
+      // ネットワークエラーや認証サーバー落ちなどはグローバルエラーとして Context に通知
+      if (!e.response) {
+        setError("サーバーに接続できませんでした。");
+      }
+
+      // 失敗はそのまま呼び出し側で処理
       throw e;
     }
   };

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -56,26 +56,28 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const login = async (user: LoginRequest): Promise<void> => {
     if (!user || !user.username || !user.password) {
-      setError("Username and password are required.");
-      return;
+      setError("ユーザー名とパスワードが必要です。");
+      throw new Error("認証が失敗しました。");
     }
 
     try {
       const data = await AuthService.login(user);
       const token = data.key;
-      if (!token) throw new Error("No token returned from server.");
 
+      if (!token) throw new Error("サーバーからトークンが返されませんでした。");
+
+      // 認証情報を state と localStorage に保存
       setToken(token);
       setCurrentUsername(user.username);
-
       localStorage.setItem(LOCALSTORAGE_TOKEN_KEY, token);
       localStorage.setItem(LOCALSTORAGE_USERNAME_KEY, user.username);
 
-      setError("");
+      setError(""); // 成功時はエラーをクリア
     } catch (e: any) {
       console.error("login error:", e);
-      const message = e.response?.data?.detail || e.message || "Login failed.";
-      setError(message);
+      // interceptor で加工済みなので e.message をそのまま使う
+      setError(e.message || "ログインに失敗しました。");
+      throw e;
     }
   };
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -94,9 +94,24 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       if (token) {
         await AuthService.logout(token);
       }
-    } catch (e: unknown) {
-      console.error("Logout error:", e);
+
+      // 成功したのでグローバルエラーはクリア
+      setError(null);
+    } catch (e: any) {
+      console.error("logout error:", e);
+
+      // ネットワークエラーや500系サーバーエラーだけグローバルに通知
+      if (
+        !e.response ||
+        (e.response.status >= 500 && e.response.status < 600)
+      ) {
+        setError(e.message);
+      }
+
+      // エラーは上位で必要に応じて処理
+      throw e;
     } finally {
+      // 認証情報を破棄（エラーがあっても確実に実行される）
       setCurrentUsername(null);
       setToken(null);
       localStorage.removeItem(LOCALSTORAGE_TOKEN_KEY);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -7,6 +7,7 @@ import {
   LOCALSTORAGE_TOKEN_KEY,
   LOCALSTORAGE_USERNAME_KEY,
 } from "../constants/storage";
+import { extractErrorMessage } from "../services/errorHandler";
 
 // 型の抽出
 type LoginRequest =
@@ -73,8 +74,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       console.error("login error:", e);
 
       // ネットワークエラーや認証サーバー落ちなどはグローバルエラーとして Context に通知
-      if (!e.response) {
-        setError("サーバーに接続できませんでした。");
+      // 重大なサーバー系エラーだけグローバルContextにセット（例：ネットワークエラー、500系など）
+      if (
+        !e.response ||
+        (e.response.status >= 500 && e.response.status < 600)
+      ) {
+        setError(extractErrorMessage(e));
       }
 
       // 失敗はそのまま呼び出し側で処理

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -7,7 +7,6 @@ import {
   LOCALSTORAGE_TOKEN_KEY,
   LOCALSTORAGE_USERNAME_KEY,
 } from "../constants/storage";
-import { extractErrorMessage } from "../services/errorHandler";
 
 // 型の抽出
 type LoginRequest =
@@ -79,7 +78,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         !e.response ||
         (e.response.status >= 500 && e.response.status < 600)
       ) {
-        setError(extractErrorMessage(e));
+        setError(e.message);
       }
 
       // 失敗はそのまま呼び出し側で処理

--- a/frontend/src/context/ErrorContext.tsx
+++ b/frontend/src/context/ErrorContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
 import type { ReactNode } from "react";
 
 // Contextで扱う値の型
@@ -19,7 +19,7 @@ const ErrorContext = createContext<ErrorContextType | null>(null);
 export const ErrorProvider = ({ children }: ErrorProviderProps) => {
   const [error, setError] = useState<string | null>(null);
 
-  const clearError = () => setError(null);
+  const clearError = useCallback(() => setError(null), []);
 
   return (
     <ErrorContext.Provider value={{ error, setError, clearError }}>

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -35,12 +35,9 @@ const Login = () => {
 
     try {
       await login({ username, password });
-      navigate("/todos"); // ログイン成功後
+      navigate("/todos"); // 成功時のみ遷移
     } catch (err) {
       console.error(err);
-      setError(
-        "ログインに失敗しました。ユーザー名とパスワードを確認してください。"
-      );
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -35,9 +35,10 @@ const Login = () => {
 
     try {
       await login({ username, password });
-      navigate("/todos"); // 成功時のみ遷移
-    } catch (err) {
+      navigate("/todos"); // 成功時は遷移
+    } catch (err: any) {
       console.error(err);
+      setError(err.message); // コンポーネント内で表示
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/todos/TodosList.tsx
+++ b/frontend/src/pages/todos/TodosList.tsx
@@ -68,11 +68,12 @@ const TodosList = () => {
     try {
       await TodoDataService.deleteTodo(selectedTodoId, token);
       setTodos((prev) => prev.filter((todo) => todo.id !== selectedTodoId));
+    } catch (error: any) {
+      console.error("Failed to delete todo:", error);
+      setLocalError(error.message || "削除に失敗しました。");
+    } finally {
       setShowDeleteModal(false);
       setSelectedTodoId(null);
-    } catch (error) {
-      console.error("Failed to delete todo:", error);
-      setLocalError("削除に失敗しました。");
     }
   }, [selectedTodoId, token]);
 

--- a/frontend/src/pages/todos/TodosList.tsx
+++ b/frontend/src/pages/todos/TodosList.tsx
@@ -46,6 +46,8 @@ const TodosList = () => {
       ) {
         // サーバー落ちやネットワーク障害など重大なエラーはグローバルに通知
         setGlobalError(error.message);
+        // コンテキスト的にも意味を補足
+        setLocalError("サーバーエラーにより、Todoを取得できませんでした。");
       } else {
         // それ以外はローカルで通知
         setLocalError(error.message);

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -13,9 +13,8 @@ const apiClient: AxiosInstance = axios.create({
 apiClient.interceptors.response.use(
   (response) => response, // 成功時はそのまま返す
   (error) => {
-    // エラー時に extractErrorMessage で整形して Promise.reject
-    const message = extractErrorMessage(error);
-    return Promise.reject(new Error(message));
+    error.message = extractErrorMessage(error); // messageだけ加工
+    return Promise.reject(error); // AxiosErrorのまま投げる
   }
 );
 

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import type { AxiosInstance } from "axios";
+import { extractErrorMessage } from "./errorHandler";
 
 const baseURL: string =
   import.meta.env.VITE_API_URL || "http://localhost:8000/api/v1";
@@ -7,5 +8,15 @@ const baseURL: string =
 const apiClient: AxiosInstance = axios.create({
   baseURL,
 });
+
+// レスポンス interceptor を追加
+apiClient.interceptors.response.use(
+  (response) => response, // 成功時はそのまま返す
+  (error) => {
+    // エラー時に extractErrorMessage で整形して Promise.reject
+    const message = extractErrorMessage(error);
+    return Promise.reject(new Error(message));
+  }
+);
 
 export default apiClient;

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -25,9 +25,26 @@ class AuthService {
         data
       );
       return response.data;
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error during login:", error);
-      throw error;
+
+      const data = error.response?.data;
+
+      // DRF標準のキー順にエラーメッセージを抽出
+      const message =
+        data?.detail ||
+        data?.non_field_errors?.[0] ||
+        Object.values(data || {})[0]?.[0] ||
+        error.message ||
+        "ログインに失敗しました。";
+
+      // よくある英語メッセージを日本語化
+      const translated =
+        message === "Unable to log in with provided credentials."
+          ? "ユーザー名またはパスワードが正しくありません。"
+          : message;
+
+      throw new Error(translated);
     }
   }
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,4 +1,5 @@
 import apiClient from "./apiClient";
+import { extractErrorMessage } from "./errorHandler";
 import type { paths } from "../types/api"; // openapi-typescript で生成された型
 
 // 型の抽出
@@ -26,25 +27,7 @@ class AuthService {
       );
       return response.data;
     } catch (error: any) {
-      console.error("Error during login:", error);
-
-      const data = error.response?.data;
-
-      // DRF標準のキー順にエラーメッセージを抽出
-      const message =
-        data?.detail ||
-        data?.non_field_errors?.[0] ||
-        Object.values(data || {})[0]?.[0] ||
-        error.message ||
-        "ログインに失敗しました。";
-
-      // よくある英語メッセージを日本語化
-      const translated =
-        message === "Unable to log in with provided credentials."
-          ? "ユーザー名またはパスワードが正しくありません。"
-          : message;
-
-      throw new Error(translated);
+      throw new Error(extractErrorMessage(error));
     }
   }
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -41,16 +41,11 @@ class AuthService {
   }
 
   async signup(data: SignupRequest): Promise<SignupResponse> {
-    try {
-      const response = await apiClient.post<SignupResponse>(
-        "/dj-rest-auth/registration/",
-        data
-      );
-      return response.data;
-    } catch (error) {
-      console.error("Error during signup:", error);
-      throw error;
-    }
+    const response = await apiClient.post<SignupResponse>(
+      "/dj-rest-auth/registration/",
+      data
+    );
+    return response.data;
   }
 }
 

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -28,21 +28,16 @@ class AuthService {
   }
 
   async logout(token: string): Promise<LogoutResponse> {
-    try {
-      const response = await apiClient.post<LogoutResponse>(
-        "/dj-rest-auth/logout/",
-        {}, // requestBodyはないけどaxiosのpostは第2引数が必要なので空オブジェクト
-        {
-          headers: {
-            Authorization: token ? `Token ${token}` : "",
-          },
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error("Error during logout:", error);
-      throw error;
-    }
+    const response = await apiClient.post<LogoutResponse>(
+      "/dj-rest-auth/logout/",
+      {}, // requestBodyはないけどaxiosのpostは第2引数が必要なので空オブジェクト
+      {
+        headers: {
+          Authorization: token ? `Token ${token}` : "",
+        },
+      }
+    );
+    return response.data;
   }
 
   async signup(data: SignupRequest): Promise<SignupResponse> {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,5 +1,4 @@
 import apiClient from "./apiClient";
-import { extractErrorMessage } from "./errorHandler";
 import type { paths } from "../types/api"; // openapi-typescript で生成された型
 
 // 型の抽出
@@ -20,15 +19,12 @@ type SignupResponse =
 
 class AuthService {
   async login(data: LoginRequest): Promise<LoginResponse> {
-    try {
-      const response = await apiClient.post<LoginResponse>(
-        "/dj-rest-auth/login/",
-        data
-      );
-      return response.data;
-    } catch (error: any) {
-      throw new Error(extractErrorMessage(error));
-    }
+    // try/catch を書かなくても、エラー時には interceptor で整形される
+    const response = await apiClient.post<LoginResponse>(
+      "/dj-rest-auth/login/",
+      data
+    );
+    return response.data;
   }
 
   async logout(token: string): Promise<LogoutResponse> {

--- a/frontend/src/services/errorHandler.ts
+++ b/frontend/src/services/errorHandler.ts
@@ -1,0 +1,21 @@
+export const extractErrorMessage = (error: any): string => {
+  const data = error.response?.data;
+
+  if (!data) return error.message || "サーバーに接続できませんでした。";
+
+  if (typeof data === "string") return data;
+
+  const message =
+    data.detail ||
+    data.non_field_errors?.[0] ||
+    Object.values(data)[0]?.[0] ||
+    error.message ||
+    "エラーが発生しました。";
+
+  switch (message) {
+    case "Unable to log in with provided credentials.":
+      return "ユーザー名またはパスワードが正しくありません。";
+    default:
+      return message;
+  }
+};

--- a/frontend/src/services/errorHandler.ts
+++ b/frontend/src/services/errorHandler.ts
@@ -1,7 +1,16 @@
 export const extractErrorMessage = (error: any): string => {
+  const status = error.response?.status;
   const data = error.response?.data;
 
-  if (!data) return error.message || "サーバーに接続できませんでした。";
+  if (!data) {
+    // ネットワークエラーやサーバー応答なし
+    if (!error.response) return "サーバーに接続できませんでした。";
+    // ステータスが500系なら固定メッセージ
+    if (status >= 500 && status < 600)
+      return "サーバーで問題が発生しました。時間を置いて再度お試しください。";
+    // それ以外はとりあえずerror.message
+    return error.message || "不明なエラーが発生しました。";
+  }
 
   if (typeof data === "string") return data;
 

--- a/frontend/src/services/errorHandler.ts
+++ b/frontend/src/services/errorHandler.ts
@@ -5,17 +5,11 @@ export const extractErrorMessage = (error: any): string => {
 
   if (typeof data === "string") return data;
 
-  const message =
+  return (
     data.detail ||
     data.non_field_errors?.[0] ||
     Object.values(data)[0]?.[0] ||
     error.message ||
-    "エラーが発生しました。";
-
-  switch (message) {
-    case "Unable to log in with provided credentials.":
-      return "ユーザー名またはパスワードが正しくありません。";
-    default:
-      return message;
-  }
+    "エラーが発生しました。"
+  );
 };

--- a/frontend/src/services/todos.ts
+++ b/frontend/src/services/todos.ts
@@ -1,6 +1,7 @@
 import apiClient from "./apiClient";
 import type { paths } from "../types/api"; // openapi-typescript で生成された型ファイル
 
+// --- 型定義 ---
 type TodosListResponse =
   paths["/api/v1/todos/"]["get"]["responses"]["200"]["content"]["application/json"];
 
@@ -22,45 +23,36 @@ type UpdateTodoResponse =
 type CompleteTodoResponse =
   paths["/api/v1/todos/{id}/complete/"]["put"]["responses"]["200"]["content"];
 
+// --- クラス定義 ---
 class TodoDataService {
+  // 全件取得
   async getAll(token: string): Promise<TodosListResponse> {
-    try {
-      const response = await apiClient.get<TodosListResponse>("/todos/", {
-        headers: {
-          Authorization: `Token ${token}`,
-        },
-      });
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
-  }
-
-  async createTodo(
-    data: CreateTodoRequestData,
-    token: string
-  ): Promise<CreateTodoResponse> {
-    try {
-      const response = await apiClient.post<CreateTodoResponse>(
-        "/todos/",
-        data,
-        { headers: { Authorization: `Token ${token}` } }
-      );
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
-  }
-
-  async getTodoById(id: string, token: string): Promise<GetTodoResponse> {
-    const response = await apiClient.get<GetTodoResponse>(`/todos/${id}/`, {
-      headers: {
-        Authorization: `Token ${token}`,
-      },
+    const response = await apiClient.get<TodosListResponse>("/todos/", {
+      headers: { Authorization: `Token ${token}` },
     });
     return response.data;
   }
 
+  // 新規作成
+  async createTodo(
+    data: CreateTodoRequestData,
+    token: string
+  ): Promise<CreateTodoResponse> {
+    const response = await apiClient.post<CreateTodoResponse>("/todos/", data, {
+      headers: { Authorization: `Token ${token}` },
+    });
+    return response.data;
+  }
+
+  // ID指定で取得
+  async getTodoById(id: string, token: string): Promise<GetTodoResponse> {
+    const response = await apiClient.get<GetTodoResponse>(`/todos/${id}/`, {
+      headers: { Authorization: `Token ${token}` },
+    });
+    return response.data;
+  }
+
+  // 更新
   async updateTodo(
     id: string,
     data: UpdateTodoRequestData,
@@ -69,40 +61,29 @@ class TodoDataService {
     const response = await apiClient.put<UpdateTodoResponse>(
       `/todos/${id}/`,
       data,
-      {
-        headers: {
-          Authorization: `Token ${token}`,
-        },
-      }
+      { headers: { Authorization: `Token ${token}` } }
     );
     return response.data;
   }
 
+  // 削除
   async deleteTodo(id: string | number, token: string): Promise<void> {
     await apiClient.delete(`/todos/${id}/`, {
       headers: { Authorization: `Token ${token}` },
     });
   }
 
+  // 完了処理
   async completeTodo(
     id: string | number,
     token: string
   ): Promise<CompleteTodoResponse> {
-    try {
-      const response = await apiClient.put<CompleteTodoResponse>(
-        `/todos/${id}/complete/`,
-        null,
-        {
-          headers: {
-            Authorization: `Token ${token}`,
-          },
-        }
-      );
-      return response.data;
-    } catch (error) {
-      console.error("Error completing todo:", error);
-      throw error;
-    }
+    const response = await apiClient.put<CompleteTodoResponse>(
+      `/todos/${id}/complete/`,
+      null,
+      { headers: { Authorization: `Token ${token}` } }
+    );
+    return response.data;
   }
 }
 


### PR DESCRIPTION
# 変更点
フロントエンドでのエラーハンドリングをより詳細に実装した
- ErrorToastコンポーネントの実装（500系エラーなどのトースト通知用）
- グローバルエラーがページをまたいだ時にリセットされるようにした（AppContentにて実装）
- Contextの改善
- 認証とTodoのそれぞれについて、サービスロジックの改善、および、各コンポーネントにエラーハンドリングを詳細に追加